### PR TITLE
Board API Compartmentalisation

### DIFF
--- a/Pieces.tres
+++ b/Pieces.tres
@@ -1,4 +1,0 @@
-[gd_resource type="CompressedTexture2D" load_steps=0 format=3 uid="uid://bdf6dbxbe8bud"]
-
-[resource]
-load_path = "res://.godot/imported/spritesheet.png-76e0b916bc20d45ac6900db6e21d8a9e.ctex"

--- a/scenes/Menus/main_menu/main_menu.gd
+++ b/scenes/Menus/main_menu/main_menu.gd
@@ -4,12 +4,6 @@ extends Control
 const BOARD_SCENE := preload("res://scenes/board/board.tscn")
 const AUDIO_BUS := preload("res://scenes/sound_system/default_bus_layout.tres")
 
-@export var start_button: Button
-@export var option_button: Button
-@export var exit_button: Button
-@onready var chess_two_player = preload("res://scenes/board/board.tscn") as PackedScene
-#going to add a new scene for options
-
 # Load all piece classes to prevent null pointers
 const PAWN_SCRIPT := preload("res://scenes/piece/Pawn.gd")
 const ROOK_SCRIPT := preload("res://scenes/piece/Rook.gd")
@@ -17,6 +11,10 @@ const KNIGHT_SCRIPT := preload("res://scenes/piece/Knight.gd")
 const BISHOP_SCRIPT := preload("res://scenes/piece/Bishop.gd")
 const QUEEN_SCRIPT := preload("res://scenes/piece/Queen.gd")
 const KING_SCRIPT := preload("res://scenes/piece/King.gd")
+
+@export var start_button: Button
+@export var option_button: Button
+@export var exit_button: Button
 
 var default_squares = [
 	0b0000000000000000,
@@ -75,6 +73,7 @@ var default_pieces = [
 	{"script": KNIGHT_SCRIPT, "pos": Vector2i(2, 3), "player": 1},
 	{"script": ROOK_SCRIPT, "pos": Vector2i(3, 3), "player": 1}
 ]
+
 
 func _ready():
 	get_window().size = DisplayServer.screen_get_size()

--- a/scenes/Menus/main_menu/main_menu.gd
+++ b/scenes/Menus/main_menu/main_menu.gd
@@ -91,7 +91,7 @@ func on_start_pressed() -> void:
 
 	var new_board = BOARD_SCENE.instantiate()
 	var new_pieces = BOARD_PIECES_SCRIPT.generate_pieces_from_data(default_pieces_data)
-	new_board.setup(default_squares, new_pieces)
+	new_board.setup(true, default_squares, new_pieces)
 	get_tree().root.add_child(new_board)
 	queue_free()
 

--- a/scenes/Menus/main_menu/main_menu.gd
+++ b/scenes/Menus/main_menu/main_menu.gd
@@ -2,6 +2,7 @@ class_name MainMenu
 extends Control
 
 const BOARD_SCENE := preload("res://scenes/board/board.tscn")
+const BOARD_PIECES_SCRIPT := preload("res://scenes/board/board_pieces.gd")
 const AUDIO_BUS := preload("res://scenes/sound_system/default_bus_layout.tres")
 
 # Load all piece classes to prevent null pointers
@@ -16,7 +17,7 @@ const KING_SCRIPT := preload("res://scenes/piece/King.gd")
 @export var option_button: Button
 @export var exit_button: Button
 
-var default_squares = [
+var default_squares := [
 	0b0000000000000000,
 	0b0000000000000000,
 	0b0000000000000000,
@@ -35,7 +36,7 @@ var default_squares = [
 	0b0000000000000000
 ]
 
-var default_pieces = [
+var default_pieces_data := [
 	# White Front Row
 	{"script": PAWN_SCRIPT, "pos": Vector2i(-4, -3), "player": 0},
 	{"script": PAWN_SCRIPT, "pos": Vector2i(-3, -3), "player": 0},
@@ -87,8 +88,10 @@ func _ready():
 func on_start_pressed() -> void:
 	MusicManager.stop_music()
 	await get_tree().create_timer(.5).timeout
+
 	var new_board = BOARD_SCENE.instantiate()
-	new_board.setup(default_squares, default_pieces)
+	var new_pieces = BOARD_PIECES_SCRIPT.generate_pieces_from_data(default_pieces_data)
+	new_board.setup(default_squares, new_pieces)
 	get_tree().root.add_child(new_board)
 	queue_free()
 

--- a/scenes/Menus/main_menu/main_menu.gd
+++ b/scenes/Menus/main_menu/main_menu.gd
@@ -1,6 +1,7 @@
 class_name MainMenu
 extends Control
 
+const BOARD_SCENE := preload("res://scenes/board/board.tscn")
 const AUDIO_BUS := preload("res://scenes/sound_system/default_bus_layout.tres")
 
 @export var start_button: Button
@@ -9,6 +10,71 @@ const AUDIO_BUS := preload("res://scenes/sound_system/default_bus_layout.tres")
 @onready var chess_two_player = preload("res://scenes/board/board.tscn") as PackedScene
 #going to add a new scene for options
 
+# Load all piece classes to prevent null pointers
+const PAWN_SCRIPT := preload("res://scenes/piece/Pawn.gd")
+const ROOK_SCRIPT := preload("res://scenes/piece/Rook.gd")
+const KNIGHT_SCRIPT := preload("res://scenes/piece/Knight.gd")
+const BISHOP_SCRIPT := preload("res://scenes/piece/Bishop.gd")
+const QUEEN_SCRIPT := preload("res://scenes/piece/Queen.gd")
+const KING_SCRIPT := preload("res://scenes/piece/King.gd")
+
+var default_squares = [
+	0b0000000000000000,
+	0b0000000000000000,
+	0b0000000000000000,
+	0b0000000000000000,
+	0b0000111111110000,
+	0b0000111111110000,
+	0b0000111111110000,
+	0b0000111111110000,
+	0b0000111111110000,
+	0b0000111111110000,
+	0b0000111111110000,
+	0b0000111111110000,
+	0b0000000000000000,
+	0b0000000000000000,
+	0b0000000000000000,
+	0b0000000000000000
+]
+
+var default_pieces = [
+	# White Front Row
+	{"script": PAWN_SCRIPT, "pos": Vector2i(-4, -3), "player": 0},
+	{"script": PAWN_SCRIPT, "pos": Vector2i(-3, -3), "player": 0},
+	{"script": PAWN_SCRIPT, "pos": Vector2i(-2, -3), "player": 0},
+	{"script": PAWN_SCRIPT, "pos": Vector2i(-1, -3), "player": 0},
+	{"script": PAWN_SCRIPT, "pos": Vector2i(0, -3), "player": 0},
+	{"script": PAWN_SCRIPT, "pos": Vector2i(1, -3), "player": 0},
+	{"script": PAWN_SCRIPT, "pos": Vector2i(2, -3), "player": 0},
+	{"script": PAWN_SCRIPT, "pos": Vector2i(3, -3), "player": 0},
+	# White Back Row
+	{"script": ROOK_SCRIPT, "pos": Vector2i(-4, -4), "player": 0},
+	{"script": KNIGHT_SCRIPT, "pos": Vector2i(-3, -4), "player": 0},
+	{"script": BISHOP_SCRIPT, "pos": Vector2i(-2, -4), "player": 0},
+	{"script": KING_SCRIPT, "pos": Vector2i(-1, -4), "player": 0},
+	{"script": QUEEN_SCRIPT, "pos": Vector2i(0, -4), "player": 0},
+	{"script": BISHOP_SCRIPT, "pos": Vector2i(1, -4), "player": 0},
+	{"script": KNIGHT_SCRIPT, "pos": Vector2i(2, -4), "player": 0},
+	{"script": ROOK_SCRIPT, "pos": Vector2i(3, -4), "player": 0},
+	# Black Front Row
+	{"script": PAWN_SCRIPT, "pos": Vector2i(-4, 2), "player": 1},
+	{"script": PAWN_SCRIPT, "pos": Vector2i(-3, 2), "player": 1},
+	{"script": PAWN_SCRIPT, "pos": Vector2i(-2, 2), "player": 1},
+	{"script": PAWN_SCRIPT, "pos": Vector2i(-1, 2), "player": 1},
+	{"script": PAWN_SCRIPT, "pos": Vector2i(0, 2), "player": 1},
+	{"script": PAWN_SCRIPT, "pos": Vector2i(1, 2), "player": 1},
+	{"script": PAWN_SCRIPT, "pos": Vector2i(2, 2), "player": 1},
+	{"script": PAWN_SCRIPT, "pos": Vector2i(3, 2), "player": 1},
+	# Black Back Row
+	{"script": ROOK_SCRIPT, "pos": Vector2i(-4, 3), "player": 1},
+	{"script": KNIGHT_SCRIPT, "pos": Vector2i(-3, 3), "player": 1},
+	{"script": BISHOP_SCRIPT, "pos": Vector2i(-2, 3), "player": 1},
+	{"script": KING_SCRIPT, "pos": Vector2i(-1, 3), "player": 1},
+	{"script": QUEEN_SCRIPT, "pos": Vector2i(0, 3), "player": 1},
+	{"script": BISHOP_SCRIPT, "pos": Vector2i(1, 3), "player": 1},
+	{"script": KNIGHT_SCRIPT, "pos": Vector2i(2, 3), "player": 1},
+	{"script": ROOK_SCRIPT, "pos": Vector2i(3, 3), "player": 1}
+]
 
 func _ready():
 	get_window().size = DisplayServer.screen_get_size()
@@ -22,7 +88,10 @@ func _ready():
 func on_start_pressed() -> void:
 	MusicManager.stop_music()
 	await get_tree().create_timer(.5).timeout
-	get_tree().change_scene_to_packed(chess_two_player)
+	var new_board = BOARD_SCENE.instantiate()
+	new_board.setup(default_squares, default_pieces)
+	get_tree().root.add_child(new_board)
+	queue_free()
 
 
 func on_option_pressed() -> void:

--- a/scenes/board/board.gd
+++ b/scenes/board/board.gd
@@ -163,9 +163,7 @@ func show_debug_timeline(board: Board) -> void:
 
 	var new_window = Window.new()
 	new_window.size = Vector2(600, 600)  # Set desired window size
-	var screen_size = DisplayServer.screen_get_size()
 	new_window.position = Vector2i(
-		# randi_range(0, int(screen_size.x) - 600), randi_range(0, int(screen_size.y) - 600)
 		debug_timelines.size() * 20 + 20,
 		debug_timelines.size() * 20 + 20
 	)

--- a/scenes/board/board.gd
+++ b/scenes/board/board.gd
@@ -68,17 +68,23 @@ func _input(event) -> void:
 			# Try to put down piece
 			if (
 				squares.has_floor_at(hovered_square)
-				and Piece.movement_safe_for_king(pieces.held_piece.movement_outcome_at(hovered_square))
+				and Piece.movement_safe_for_king(
+					pieces.held_piece.movement_outcome_at(hovered_square)
+				)
 			):
 				# Put down piece
 				pieces.held_piece.move_to(hovered_square)
 				half_moves += 1
 
 				# Verify checkmate state for opposite player
-				var king_to_consider = pieces.white_king if half_moves % 2 == 0 else pieces.black_king
-				if is_og() and in_checkmate(king_to_consider):
+				var king_to_consider = (
+					pieces.white_king if half_moves % 2 == 0 else pieces.black_king
+				)
+				if is_og() and king_to_consider.in_checkmate():
 					AudioManager.play_sound(AudioManager.movement.checkmate, -15)
-					print(("Black" if king_to_consider == pieces.white_king else "White") + " wins!")
+					print(
+						("Black" if king_to_consider == pieces.white_king else "White") + " wins!"
+					)
 
 				AudioManager.play_sound(AudioManager.movement.place)
 
@@ -127,21 +133,6 @@ func branch() -> Board:
 		piece.board = new_timeline
 
 	return new_timeline
-
-
-## Returns if the supplied [param king] is in checkmate based on the current board state.
-func in_checkmate(king: King) -> bool:
-	if king.in_check():
-		# Check every possible move
-		for enemy_piece: Piece in pieces.get_children():
-			if enemy_piece.player != king.player:
-				continue
-
-			if enemy_piece.has_valid_moves():
-				return false
-
-		return true
-	return false
 
 
 ## Makes a recursive search from an origin point.

--- a/scenes/board/board.tscn
+++ b/scenes/board/board.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://c0bs6sbbrybcl"]
+[gd_scene load_steps=5 format=3 uid="uid://c0bs6sbbrybcl"]
 
 [ext_resource type="Script" uid="uid://c2uda738gndb4" path="res://scenes/board/board.gd" id="1_q07he"]
 [ext_resource type="TileSet" uid="uid://csjjpcar6usnu" path="res://assets/spritesheet.tres" id="2_kymhv"]
 [ext_resource type="Script" uid="uid://b0pypjutr31ci" path="res://scenes/board/board_squares.gd" id="3_knosr"]
+[ext_resource type="Script" uid="uid://buabp8ji67ups" path="res://scenes/board/board_pieces.gd" id="4_q07he"]
 
 [node name="Board" type="Node2D" node_paths=PackedStringArray("squares", "pieces")]
 script = ExtResource("1_q07he")
@@ -19,3 +20,4 @@ tile_set = ExtResource("2_kymhv")
 script = ExtResource("3_knosr")
 
 [node name="Pieces" type="Node2D" parent="."]
+script = ExtResource("4_q07he")

--- a/scenes/board/board.tscn
+++ b/scenes/board/board.tscn
@@ -1,11 +1,12 @@
-[gd_scene load_steps=3 format=3 uid="uid://c0bs6sbbrybcl"]
+[gd_scene load_steps=4 format=3 uid="uid://c0bs6sbbrybcl"]
 
 [ext_resource type="Script" uid="uid://c2uda738gndb4" path="res://scenes/board/board.gd" id="1_q07he"]
 [ext_resource type="TileSet" uid="uid://csjjpcar6usnu" path="res://assets/spritesheet.tres" id="2_kymhv"]
+[ext_resource type="Script" uid="uid://b0pypjutr31ci" path="res://scenes/board/board_squares.gd" id="3_knosr"]
 
-[node name="Board" type="Node2D" node_paths=PackedStringArray("square_map", "pieces")]
+[node name="Board" type="Node2D" node_paths=PackedStringArray("squares", "pieces")]
 script = ExtResource("1_q07he")
-square_map = NodePath("Squares")
+squares = NodePath("Squares")
 pieces = NodePath("Pieces")
 
 [node name="Camera" type="Camera2D" parent="."]
@@ -15,5 +16,6 @@ zoom = Vector2(8, 8)
 z_index = -1
 rotation = -4.80598e-05
 tile_set = ExtResource("2_kymhv")
+script = ExtResource("3_knosr")
 
 [node name="Pieces" type="Node2D" parent="."]

--- a/scenes/board/board_pieces.gd
+++ b/scenes/board/board_pieces.gd
@@ -75,7 +75,9 @@ static func spawn_piece(piece_script: Script, pos: Vector2i, player: int) -> Pie
 	var new_piece = PIECE_SCENE.instantiate()
 	new_piece.set_script(piece_script)
 	new_piece.setup(null, pos, player)
-	new_piece.name = ("Black" if player else "White") + piece_script.get_global_name() + " "+ str(pos)
+	new_piece.name = (
+		("Black" if player else "White") + piece_script.get_global_name() + " " + str(pos)
+	)
 	return new_piece
 
 

--- a/scenes/board/board_pieces.gd
+++ b/scenes/board/board_pieces.gd
@@ -3,11 +3,19 @@ extends Node2D
 
 const PIECE_SCENE := preload("res://scenes/piece/piece.tscn")
 
-# Nodes
+## The [Board] the squares are associated with
 var board: Board
+
+## A map with keys of Vector2i and values of Piece, describing the current location of pieces
 var map: Dictionary = {}
-var held_piece: Node
+
+## The current piece being manipulated
+var held_piece: Piece
+
+## Player 0's king
 var white_king: King
+
+## Player 1's king
 var black_king: King
 
 
@@ -67,7 +75,7 @@ static func spawn_piece(piece_script: Script, pos: Vector2i, player: int) -> Pie
 	var new_piece = PIECE_SCENE.instantiate()
 	new_piece.set_script(piece_script)
 	new_piece.setup(null, pos, player)
-	new_piece.name = ("White" if player else "Black") + piece_script.get_global_name()
+	new_piece.name = ("Black" if player else "White") + piece_script.get_global_name() + " "+ str(pos)
 	return new_piece
 
 

--- a/scenes/board/board_pieces.gd
+++ b/scenes/board/board_pieces.gd
@@ -1,0 +1,55 @@
+class_name BoardPieces
+extends Node2D
+
+const PIECE_SCENE := preload("res://scenes/piece/piece.tscn")
+
+# Nodes
+var map: Dictionary = {}
+var held_piece: Node
+var white_king: King
+var black_king: King
+
+
+func setup(board, pieces_data):
+	for child in get_children():
+		child.queue_free()
+
+	# Load Pieces
+	for piece_data in pieces_data:
+		# Iterate through the board, creating instances of each piece
+		var piece = spawn_piece(board, piece_data.script, piece_data.pos, piece_data.player)
+		if piece is King:
+			if not piece_data.player:
+				if white_king:
+					push_error("Multiple white kings defined")
+				white_king = piece
+			else:
+				if black_king:
+					push_error("Multiple black kings defined")
+				black_king = piece
+
+	if not white_king:
+		push_error("No white king defined")
+
+	if not black_king:
+		push_error("No black king defined")
+
+
+## Returns the [Piece] in the board's [member map] at [param pos], or
+## [code]null[/code] if absent.
+func at(pos: Vector2i) -> Piece:
+	return map.get(pos)
+
+
+## Creates a scene instance of the piece and places it in the pieces array
+##[param piece_script]: The proloaded script for the piece
+##[param pos]: The Vector2i for the board location
+##[param player]: The player that controls the piece
+func spawn_piece(board, piece_script: Script, pos: Vector2i, player: int) -> Piece:
+	var new_piece = PIECE_SCENE.instantiate()
+	new_piece.set_script(piece_script)
+	new_piece.setup(board, pos, player)
+	map[pos] = new_piece
+	add_child(new_piece)
+	new_piece.name = ("White" if player else "Black") + piece_script.get_global_name()
+	return new_piece

--- a/scenes/board/board_pieces.gd.uid
+++ b/scenes/board/board_pieces.gd.uid
@@ -1,0 +1,1 @@
+uid://buabp8ji67ups

--- a/scenes/board/board_squares.gd
+++ b/scenes/board/board_squares.gd
@@ -51,13 +51,13 @@ func set_at(pos: Vector2i, on: bool) -> void:
 
 ## Re-calculates all the tiles. If supplied a ## [param selected_piece], the floor will indicating
 ##valid movement options for that piece.
-func recolor(selected_piece: Piece, board: Board) -> void:
+func recolor(selected_piece: Piece, pieces: BoardPieces) -> void:
 	# Load Squares
 	for col in range(0, 16):
 		for row in range(0, 16):
 			var map_cell = Vector2i(row - 8, col - 8)
 			if has_floor_at(map_cell):
-				var tiles = calculate_square_tile_at(map_cell, selected_piece, board)
+				var tiles = calculate_square_tile_at(map_cell, selected_piece, pieces)
 				set_cell(map_cell, TILESET_ID, tiles.light if (row + col) % 2 == 0 else tiles.dark)
 			elif get_cell_tile_data(map_cell):
 				erase_cell(map_cell)
@@ -67,9 +67,9 @@ func recolor(selected_piece: Piece, board: Board) -> void:
 ## for an optional [param selected_piece]. Output format is a dictionary of the form
 ## [code]{"light": LIGHT_TILE, "dark": DARK_TILE}[/code]
 func calculate_square_tile_at(
-	map_cell: Vector2i, selected_piece: Piece, board: Board
+	map_cell: Vector2i, selected_piece: Piece, pieces: BoardPieces
 ) -> Dictionary:
-	var piece_at_cell = board.get_piece_at(map_cell)
+	var piece_at_cell = pieces.at(map_cell)
 	if piece_at_cell is King:
 		if piece_at_cell.in_check():
 			return {"light": ORANGE_TILE, "dark": DARK_ORANGE_TILE}

--- a/scenes/board/board_squares.gd
+++ b/scenes/board/board_squares.gd
@@ -1,0 +1,111 @@
+class_name BoardSquares
+extends TileMapLayer
+
+# Sprite Indices
+const TILESET_ID := 0
+
+const WHITE_TILE := Vector2i(0, 3)
+const BLACK_TILE := Vector2i(0, 7)
+const CYAN_TILE := Vector2i(1, 3)
+const DARK_CYAN_TILE := Vector2i(1, 7)
+const GREEN_TILE := Vector2i(2, 3)
+const DARK_GREEN_TILE := Vector2i(2, 7)
+const PURPLE_TILE := Vector2i(3, 3)
+const DARK_PURPLE_TILE := Vector2i(3, 7)
+const ORANGE_TILE := Vector2i(4, 3)
+const DARK_ORANGE_TILE := Vector2i(4, 7)
+const RED_TILE := Vector2i(5, 3)
+const DARK_RED_TILE := Vector2i(5, 7)
+
+# State
+var floor_data := []
+var last_tile_highlighted: Vector2i
+
+
+## Returns [code]true[/true] if the [param pos] is a valid square that pieces can be on,
+## as opposed to a hole.
+func has_floor_at(pos: Vector2i) -> bool:
+	if pos.x < -8 or pos.x > 8:
+		return false
+	return get_bit(floor_data[pos.y - 8], 16 - pos.x - 8 - 1)
+
+
+## Creates or destroys a square tile on the board. Returns if a change was made or not
+## [param pos]: The tile to change
+## [param on]: Whether to enable or disable the file
+func set_at(pos: Vector2i, on: bool) -> void:
+	if pos.clampi(-8, 7) != pos:
+		return
+
+	var has_floor := has_floor_at(pos)
+	var to_add := 1 << (16 - pos.x - 8 - 1)
+
+	if has_floor and not on:
+		to_add = -1 * to_add
+	elif not (has_floor and on):
+		return
+
+	floor_data[pos.y - 8] += to_add
+	return
+
+
+## Re-calculates all the tiles. If supplied a ## [param selected_piece], the floor will indicating
+##valid movement options for that piece.
+func recolor(selected_piece: Piece, board: Board) -> void:
+	# Load Squares
+	for col in range(0, 16):
+		for row in range(0, 16):
+			var map_cell = Vector2i(row - 8, col - 8)
+			if has_floor_at(map_cell):
+				var tiles = calculate_square_tile_at(map_cell, selected_piece, board)
+				set_cell(map_cell, TILESET_ID, tiles.light if (row + col) % 2 == 0 else tiles.dark)
+			elif get_cell_tile_data(map_cell):
+				erase_cell(map_cell)
+
+
+## Returns what tiles should be used for a given [param map_cell], indicating valid movement options
+## for an optional [param selected_piece]. Output format is a dictionary of the form
+## [code]{"light": LIGHT_TILE, "dark": DARK_TILE}[/code]
+func calculate_square_tile_at(
+	map_cell: Vector2i, selected_piece: Piece, board: Board
+) -> Dictionary:
+	var piece_at_cell = board.get_piece_at(map_cell)
+	if piece_at_cell is King:
+		if piece_at_cell.in_check():
+			return {"light": ORANGE_TILE, "dark": DARK_ORANGE_TILE}
+
+	if selected_piece:
+		if selected_piece.board_pos == map_cell:
+			return {"light": CYAN_TILE, "dark": DARK_CYAN_TILE}
+
+		var outcome = selected_piece.movement_outcome_at(map_cell)
+
+		if outcome == Piece.MovementOutcome.AVAILABLE:
+			return {"light": GREEN_TILE, "dark": DARK_GREEN_TILE}
+
+		if outcome == Piece.MovementOutcome.CAPTURE:
+			return {"light": RED_TILE, "dark": DARK_RED_TILE}
+
+	return {"light": WHITE_TILE, "dark": BLACK_TILE}
+
+
+func set_highlight(pos):
+# Reset previous tile
+	if pos != last_tile_highlighted and last_tile_highlighted != null:
+		if get_cell_atlas_coords(last_tile_highlighted) == CYAN_TILE:
+			set_cell(last_tile_highlighted, TILESET_ID, WHITE_TILE)
+		elif get_cell_atlas_coords(last_tile_highlighted) == DARK_CYAN_TILE:
+			set_cell(last_tile_highlighted, TILESET_ID, BLACK_TILE)
+
+# Set current tile
+	if get_cell_atlas_coords(pos) == WHITE_TILE:
+		set_cell(pos, TILESET_ID, CYAN_TILE)
+		last_tile_highlighted = pos
+	elif get_cell_atlas_coords(pos) == BLACK_TILE:
+		set_cell(pos, TILESET_ID, DARK_CYAN_TILE)
+		last_tile_highlighted = pos
+
+
+## General utility method. Gets the bit in the [param pos] position in a [param bitfield]
+static func get_bit(bitfield: int, pos: int) -> int:
+	return (bitfield >> pos) & 1

--- a/scenes/board/board_squares.gd
+++ b/scenes/board/board_squares.gd
@@ -3,7 +3,6 @@ extends TileMapLayer
 
 # Sprite Indices
 const TILESET_ID := 0
-
 const WHITE_TILE := Vector2i(0, 3)
 const BLACK_TILE := Vector2i(0, 7)
 const CYAN_TILE := Vector2i(1, 3)
@@ -17,16 +16,25 @@ const DARK_ORANGE_TILE := Vector2i(4, 7)
 const RED_TILE := Vector2i(5, 3)
 const DARK_RED_TILE := Vector2i(5, 7)
 
-# State
+## The [Board] the squares are associated with
 var board: Board
+
+## An array of length 16 comprised of 16 bit uints, representing the
+## presence or absence of a floor tile in a grid
 var floor_data := []
+
+## The previous known location the cursor was hovering, to allow for easy resetting to normal
 var last_tile_highlighted: Vector2i
 
 
+## Sets all the root information for board squares
+## [param board]: Value to set [member board] to
+## [param floor_data]: Value to set [member floor_data] to
 func setup(board, floor_data) -> void:
 	self.board = board
 	self.floor_data = floor_data
-	self.recolor(null)
+	if board.is_primary:
+		self.recolor(null)
 
 
 ## Returns [code]true[/true] if the [param pos] is a valid square that pieces can be on,

--- a/scenes/board/board_squares.gd.uid
+++ b/scenes/board/board_squares.gd.uid
@@ -1,0 +1,1 @@
+uid://b0pypjutr31ci

--- a/scenes/piece/Bishop.gd
+++ b/scenes/piece/Bishop.gd
@@ -13,7 +13,7 @@ func _movement(pos: Vector2i) -> MovementOutcome:
 	if not is_diagonal(pos):
 		return MovementOutcome.BLOCKED
 
-	var piece_to_capture = board.get_piece_at(pos)
+	var piece_to_capture = board.pieces.at(pos)
 
 	# Can't capture own piece
 	if is_friendly(piece_to_capture):

--- a/scenes/piece/King.gd
+++ b/scenes/piece/King.gd
@@ -70,6 +70,21 @@ func in_check_at(pos: Vector2i) -> Piece:
 	return null
 
 
+## Returns if the supplied [param king] is in checkmate based on the current board state.
+func in_checkmate() -> bool:
+	if in_check():
+		# Check every possible move
+		for enemy_piece: Piece in board.pieces.get_children():
+			if enemy_piece.player != player:
+				continue
+
+			if enemy_piece.has_valid_moves():
+				return false
+
+		return true
+	return false
+
+
 func movement_actions(pos: Vector2i) -> void:
 	var castle_target = get_castle_target_when_moved_to(pos)
 	if castle_target:

--- a/scenes/piece/King.gd
+++ b/scenes/piece/King.gd
@@ -9,7 +9,7 @@ func setup(board: Board, pos: Vector2i, player: int) -> void:
 
 
 func _movement(pos: Vector2i) -> MovementOutcome:
-	var piece_to_capture = board.get_piece_at(pos)
+	var piece_to_capture = board.pieces.at(pos)
 
 	if is_friendly(piece_to_capture):
 		return MovementOutcome.BLOCKED

--- a/scenes/piece/Knight.gd
+++ b/scenes/piece/Knight.gd
@@ -23,7 +23,7 @@ func _movement(pos: Vector2i) -> MovementOutcome:
 	if not check_knight_shape(pos):
 		return MovementOutcome.BLOCKED
 
-	var piece_to_capture = board.get_piece_at(pos)
+	var piece_to_capture = board.pieces.at(pos)
 
 	# Can't capture own piece
 	if is_friendly(piece_to_capture):

--- a/scenes/piece/Pawn.gd
+++ b/scenes/piece/Pawn.gd
@@ -1,10 +1,14 @@
 class_name Pawn
 extends Piece
 
+@export var forward_direction: int
 
 func setup(board: Board, pos: Vector2i, player: int) -> void:
 	self.point_value = 1
 	self.sprite_index = 0
+
+	forward_direction = -1 if player else 1
+
 	super.setup(board, pos, player)
 
 

--- a/scenes/piece/Pawn.gd
+++ b/scenes/piece/Pawn.gd
@@ -3,6 +3,7 @@ extends Piece
 
 @export var forward_direction: int
 
+
 func setup(board: Board, pos: Vector2i, player: int) -> void:
 	self.point_value = 1
 	self.sprite_index = 0

--- a/scenes/piece/Pawn.gd
+++ b/scenes/piece/Pawn.gd
@@ -9,7 +9,7 @@ func setup(board: Board, pos: Vector2i, player: int) -> void:
 
 
 func _movement(pos: Vector2i) -> MovementOutcome:
-	var piece_to_capture = board.get_piece_at(pos)
+	var piece_to_capture = board.pieces.at(pos)
 
 	# Can't capture own piece
 	if is_friendly(piece_to_capture):
@@ -42,7 +42,7 @@ func _movement(pos: Vector2i) -> MovementOutcome:
 
 
 func get_en_passant_target(pos: Vector2i) -> Pawn:
-	var target = board.get_piece_at(pos + Vector2i(0, -self.forward_direction))
+	var target = board.pieces.at(pos + Vector2i(0, -self.forward_direction))
 
 	# Target must:
 	if not target:

--- a/scenes/piece/Queen.gd
+++ b/scenes/piece/Queen.gd
@@ -9,7 +9,7 @@ func setup(board: Board, pos: Vector2i, player: int) -> void:
 
 
 func _movement(pos: Vector2i) -> MovementOutcome:
-	var piece_to_capture = board.get_piece_at(pos)
+	var piece_to_capture = board.pieces.at(pos)
 
 	# Can't capture own piece
 	if is_friendly(piece_to_capture):

--- a/scenes/piece/Rook.gd
+++ b/scenes/piece/Rook.gd
@@ -13,7 +13,7 @@ func _movement(pos: Vector2i) -> MovementOutcome:
 	if not (is_horizontal(pos) or is_vertical(pos)):
 		return MovementOutcome.BLOCKED
 
-	var piece_to_capture = board.get_piece_at(pos)
+	var piece_to_capture = board.pieces.at(pos)
 
 	# Can't capture own piece
 	if is_friendly(piece_to_capture):

--- a/scenes/piece/piece.gd
+++ b/scenes/piece/piece.gd
@@ -4,7 +4,7 @@ extends Node2D
 enum MovementOutcome { BLOCKED, AVAILABLE, CAPTURE, AVAILABLE_BAD_FOR_KING, CAPTURE_BAD_FOR_KING }
 enum DebugTimelineModes { NONE, LOSSES, ALL }
 
-const DEBUG_TIMELINE_MODE := DebugTimelineModes.ALL
+const DEBUG_TIMELINE_MODE := DebugTimelineModes.NONE
 
 # @xport is used for properties that need to persist after running [method branch].
 
@@ -179,11 +179,13 @@ func movement_outcome_at(pos: Vector2i) -> MovementOutcome:
 			elif move_outcome == MovementOutcome.CAPTURE:
 				move_outcome = MovementOutcome.CAPTURE_BAD_FOR_KING
 
-			new_timeline.squares.recolor(check_piece)
-
 		# Debugging
 		if show_debug_window:
 			board.show_debug_timeline(new_timeline)
+			if check_piece:
+				new_timeline.squares.recolor(check_piece)
+			else:
+				new_timeline.squares.recolor(null)
 		else:
 			new_timeline.queue_free()
 

--- a/scenes/piece/piece.gd
+++ b/scenes/piece/piece.gd
@@ -121,7 +121,7 @@ func has_valid_moves() -> bool:
 	for row in range(0, 16):
 		for col in range(0, 16):
 			var map_cell = Vector2i(col - 8, row - 8)
-			if board.has_floor_at(map_cell):
+			if board.squares.has_floor_at(map_cell):
 				if movement_safe_for_king(movement_outcome_at(map_cell)):
 					return true
 	return false
@@ -130,7 +130,7 @@ func has_valid_moves() -> bool:
 ## Determines if the piece can legally move to [param pos] based on movement rules and board state.
 func movement_outcome_at(pos: Vector2i) -> MovementOutcome:
 	# Can't move to itself or to somewhere without floor
-	if pos == board_pos or not board.has_floor_at(pos):
+	if pos == board_pos or not board.squares.has_floor_at(pos):
 		return MovementOutcome.BLOCKED
 
 	# Reset saved cells if move changed
@@ -152,19 +152,21 @@ func movement_outcome_at(pos: Vector2i) -> MovementOutcome:
 		var show_debug_window = DEBUG_TIMELINE_MODE == DebugTimelineModes.ALL
 
 		var timeline_piece: Piece = new_timeline.get_piece_at(board_pos)
-		timeline_piece.move_to(pos)
+		if timeline_piece: # TODO shouldnt be needed
+			timeline_piece.move_to(pos)
 		new_timeline.half_moves += 1
 
 		var king_to_consider: King = new_timeline.white_king if player else new_timeline.black_king
-		var check_piece = king_to_consider.in_check()
-		if check_piece:
-			if DEBUG_TIMELINE_MODE == DebugTimelineModes.LOSSES:
-				show_debug_window = true
+		if king_to_consider: # TODO shouldnt be needed
+			var check_piece = king_to_consider.in_check()
+			if check_piece:
+				if DEBUG_TIMELINE_MODE == DebugTimelineModes.LOSSES:
+					show_debug_window = true
 
-			if move_outcome == MovementOutcome.AVAILABLE:
-				move_outcome = MovementOutcome.AVAILABLE_BAD_FOR_KING
-			elif move_outcome == MovementOutcome.CAPTURE:
-				move_outcome = MovementOutcome.CAPTURE_BAD_FOR_KING
+				if move_outcome == MovementOutcome.AVAILABLE:
+					move_outcome = MovementOutcome.AVAILABLE_BAD_FOR_KING
+				elif move_outcome == MovementOutcome.CAPTURE:
+					move_outcome = MovementOutcome.CAPTURE_BAD_FOR_KING
 
 			new_timeline.color_board_squares(check_piece)
 

--- a/scenes/piece/piece.gd
+++ b/scenes/piece/piece.gd
@@ -22,11 +22,6 @@ var checked_cells_half_move: int
 var last_moved_half_move := 0
 
 
-func _ready() -> void:
-	self.set_sprite(sprite_index)
-	set_sprite(sprite_index)
-
-
 ## Sets all the root information for a piece.
 ## [param board]: The [Board] that owns the piece
 ## [param pos]: Starting position of the piece
@@ -37,6 +32,16 @@ func setup(board: Board, pos: Vector2i, player: int) -> void:
 	original_pos = board_pos
 	self.player = player
 	forward_direction = -1 if player else 1
+
+
+func _ready() -> void:
+	self.set_sprite(sprite_index)
+	set_sprite(sprite_index)
+
+
+func branch() -> Piece:
+	var new_piece = duplicate()
+	return new_piece
 
 
 ## Sets the sprite of the piece based on the owning player. White pieces get the n'th [param sprite]
@@ -79,7 +84,7 @@ func set_board_pos(pos: Vector2i) -> void:
 ## Removes the piece from its parent [Board] and removes self from memory
 func capture() -> void:
 	if board.pieces.at(board_pos) == self:
-		board.piece_map.set(board_pos, null)
+		board.pieces.map.set(board_pos, null)
 		board.pieces.remove_child(self)
 
 		if board.is_og():
@@ -170,7 +175,7 @@ func movement_outcome_at(pos: Vector2i) -> MovementOutcome:
 				elif move_outcome == MovementOutcome.CAPTURE:
 					move_outcome = MovementOutcome.CAPTURE_BAD_FOR_KING
 
-			new_timeline.color_board_squares(check_piece)
+			new_timeline.squares.recolor(check_piece)
 
 		# Debugging
 		if show_debug_window:

--- a/scenes/piece/piece.gd
+++ b/scenes/piece/piece.gd
@@ -53,10 +53,10 @@ func set_sprite(sprite: int) -> void:
 ## Additional movement actions will be triggered automatically.
 func move_to(pos: Vector2i) -> void:
 	# Pick up original piece
-	board.piece_map.set(board_pos, null)
+	board.pieces.map.set(board_pos, null)
 
 	# Capture
-	var replaced_piece = board.get_piece_at(pos)
+	var replaced_piece = board.pieces.at(pos)
 	if replaced_piece:
 		replaced_piece.capture()
 
@@ -67,7 +67,7 @@ func move_to(pos: Vector2i) -> void:
 	previous_position = board_pos
 	set_board_pos(pos)
 	last_moved_half_move = board.half_moves
-	board.piece_map[pos] = self
+	board.pieces.map[pos] = self
 
 
 ## Changes the visual and saved [member board_pos] to [param pos]
@@ -78,7 +78,7 @@ func set_board_pos(pos: Vector2i) -> void:
 
 ## Removes the piece from its parent [Board] and removes self from memory
 func capture() -> void:
-	if board.get_piece_at(board_pos) == self:
+	if board.pieces.at(board_pos) == self:
 		board.piece_map.set(board_pos, null)
 		board.pieces.remove_child(self)
 
@@ -151,12 +151,12 @@ func movement_outcome_at(pos: Vector2i) -> MovementOutcome:
 		var new_timeline: Board = board.branch()
 		var show_debug_window = DEBUG_TIMELINE_MODE == DebugTimelineModes.ALL
 
-		var timeline_piece: Piece = new_timeline.get_piece_at(board_pos)
+		var timeline_piece: Piece = new_timeline.pieces.at(board_pos)
 		if timeline_piece: # TODO shouldnt be needed
 			timeline_piece.move_to(pos)
 		new_timeline.half_moves += 1
 
-		var king_to_consider: King = new_timeline.white_king if player else new_timeline.black_king
+		var king_to_consider: King = new_timeline.pieces.white_king if player else new_timeline.pieces.black_king
 		if king_to_consider: # TODO shouldnt be needed
 			var check_piece = king_to_consider.in_check()
 			if check_piece:

--- a/scenes/piece/piece.gd
+++ b/scenes/piece/piece.gd
@@ -152,12 +152,14 @@ func movement_outcome_at(pos: Vector2i) -> MovementOutcome:
 		var show_debug_window = DEBUG_TIMELINE_MODE == DebugTimelineModes.ALL
 
 		var timeline_piece: Piece = new_timeline.pieces.at(board_pos)
-		if timeline_piece: # TODO shouldnt be needed
+		if timeline_piece:  # TODO shouldnt be needed
 			timeline_piece.move_to(pos)
 		new_timeline.half_moves += 1
 
-		var king_to_consider: King = new_timeline.pieces.white_king if player else new_timeline.pieces.black_king
-		if king_to_consider: # TODO shouldnt be needed
+		var king_to_consider: King = (
+			new_timeline.pieces.white_king if player else new_timeline.pieces.black_king
+		)
+		if king_to_consider:  # TODO shouldnt be needed
 			var check_piece = king_to_consider.in_check()
 			if check_piece:
 				if DEBUG_TIMELINE_MODE == DebugTimelineModes.LOSSES:

--- a/scenes/piece/piece.tscn
+++ b/scenes/piece/piece.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://c7k57d4hiqhd1"]
 
 [ext_resource type="Script" uid="uid://dbfahhjcplmb6" path="res://scenes/piece/piece.gd" id="1_huli3"]
-[ext_resource type="Texture2D" uid="uid://bdf6dbxbe8bud" path="res://Pieces.tres" id="2_huli3"]
+[ext_resource type="Texture2D" uid="uid://p0vmoyd3s210" path="res://assets/spritesheet.png" id="2_huli3"]
 
 [node name="Piece" type="Node2D"]
 script = ExtResource("1_huli3")


### PR DESCRIPTION
I'm trying to move all the 8 billion functions in `Board` to the sub-nodes where they would be most appropriate. For instance, checking a tile at a position might be done with `Board.squares.at()` instead of `Board.has_floor_at()`

As part of this, I'm working on making instantiating a board and its sub-components easier, especially when using `Board.branch()`. This might not go anywhere, but I'm sick of the bloated board file and want to see if I can fix it without many negative effects.